### PR TITLE
Fix macro-check for using Flipper in AppDelegate.swift

### DIFF
--- a/template/ios/HelloWorld/AppDelegate.swift
+++ b/template/ios/HelloWorld/AppDelegate.swift
@@ -1,5 +1,5 @@
 import UIKit
-#if DEBUG
+#if FB_SONARKIT_ENABLED
 import FlipperKit
 #endif
 
@@ -38,7 +38,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, RCTBridgeDelegate {
   }
 
   private func initializeFlipper(with application: UIApplication) {
-    #if DEBUG
+    #if FB_SONARKIT_ENABLED
     let client = FlipperClient.shared()
     let layoutDescriptionMapper = SKDescriptorMapper(defaults: ())
     client?.add(FlipperKitLayoutPlugin(rootNode: application, with: layoutDescriptionMapper))


### PR DESCRIPTION
This fix is for the case developer prefers to use use_framework! and disable use_flipper! in Podfile